### PR TITLE
Fix R6031 error with python3.4

### DIFF
--- a/cpyHook.i
+++ b/cpyHook.i
@@ -9,8 +9,8 @@
     #define PY3K
   #endif
 
-  PyObject* callback_funcs[WH_MAX];
-  HHOOK hHooks[WH_MAX];
+  PyObject* callback_funcs[WH_MAX + 1];
+  HHOOK hHooks[WH_MAX + 1];
   BYTE key_state[256];
 %}
 
@@ -26,8 +26,8 @@
 
 %init %{
   memset(key_state, 0, 256);
-  memset(callback_funcs, 0, WH_MAX);
-  memset(hHooks, 0, WH_MAX);
+  memset(callback_funcs, 0, (WH_MAX + 1) * sizeof(PyObject*));
+  memset(hHooks, 0, (WH_MAX + 1) * sizeof(HHOOK));
   PyEval_InitThreads();
   
   // get initial key state


### PR DESCRIPTION
In WinUser.h:
```
#if (_WIN32_WINNT >= 0x0400)
#define WH_KEYBOARD_LL     13
#define WH_MOUSE_LL        14
#endif // (_WIN32_WINNT >= 0x0400)

#if(WINVER >= 0x0400)
#if (_WIN32_WINNT >= 0x0400)
#define WH_MAX             14
#else
#define WH_MAX             12
#endif // (_WIN32_WINNT >= 0x0400)
#else
#define WH_MAX             11
#endif
```
So size of ```callback_funcs```  and ```hHooks``` should be bigger than WH_MAX 